### PR TITLE
Resolve Serial Manager Crash on Rapid Start/Stop Calls

### DIFF
--- a/include/esp32/serial.hpp
+++ b/include/esp32/serial.hpp
@@ -27,17 +27,9 @@ class serial_manager_t {
     std::atomic<bool> should_send_data{false};
     std::atomic<bool> is_serial_write{false};
 
-    [[nodiscard]] std::vector<std::string> get_all_ports() const;
-    [[nodiscard]] std::unordered_set<std::string>
-    get_chosen_ports() const { // TODO(blake): Is a copy really what we want here?
-        const std::scoped_lock lock{mutex_};
-        return chosen_ports_;
-    }
-    [[nodiscard]] std::vector<std::string>
-    return_data_stream() const { // TODO(blake): Is a copy really what we want here?
-        const std::scoped_lock lock{mutex_};
-        return input_stream_;
-    }
+    [[nodiscard]] std::vector<std::string>        get_all_ports() const;
+    [[nodiscard]] std::unordered_set<std::string> get_chosen_ports() const;
+    [[nodiscard]] std::vector<std::string>        return_data_stream() const;
 
     void     send_data(const std::string& msg);
     void     receive_data();

--- a/include/esp32/serial.hpp
+++ b/include/esp32/serial.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <map>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <thread>
@@ -16,27 +16,38 @@ class serial_manager_t {
   public:
     explicit serial_manager_t(int baud_rate = 115'200, int timeout_ms = 0, log_fn_t log = nullptr)
         : log_{std::move(log)}, baud_rate_(baud_rate), timeout_ms_(timeout_ms) {}
-    ~serial_manager_t() {
-        keep_running = false;
-        if (worker_.joinable()) { worker_.join(); }
-        close_all();
-    };
+    ~serial_manager_t();
 
-    std::atomic<bool>                      keep_running{true};
-    std::atomic<bool>                      should_send_data{false};
-    std::atomic<bool>                      is_serial_write{false};
-    std::map<std::string, serial::Serial*> export_ports() { return ports_; }
-    std::unordered_set<std::string>        return_chosen() { return chosen_ports_; }
-    std::vector<std::string>               return_data_stream() const { return input_stream_; }
-    void                                   send_data(const std::string& msg);
-    void                                   receive_data();
-    void                                   read_all();
-    void                                   start();
-    void                                   add_port(const std::string& port);
-    void                                   remove_port(const std::string& port);
-    void                                   clean_ports();
-    void                                   close_port(const std::string& port);
-    void                                   close_all();
+    serial_manager_t(const serial_manager_t&)            = delete;
+    serial_manager_t& operator=(const serial_manager_t&) = delete;
+    serial_manager_t(serial_manager_t&&)                 = delete;
+    serial_manager_t& operator=(serial_manager_t&&)      = delete;
+
+    std::atomic<bool> keep_running{true};
+    std::atomic<bool> should_send_data{false};
+    std::atomic<bool> is_serial_write{false};
+
+    [[nodiscard]] std::vector<std::string> get_all_ports() const;
+    [[nodiscard]] std::unordered_set<std::string>
+    get_chosen_ports() const { // TODO(blake): Is a copy really what we want here?
+        const std::scoped_lock lock{mutex_};
+        return chosen_ports_;
+    }
+    [[nodiscard]] std::vector<std::string>
+    return_data_stream() const { // TODO(blake): Is a copy really what we want here?
+        const std::scoped_lock lock{mutex_};
+        return input_stream_;
+    }
+
+    void     send_data(const std::string& msg);
+    void     receive_data();
+    void     read_all();
+    void     start();
+    void     add_port(const std::string& port);
+    void     remove_port(const std::string& port);
+    void     clean_ports();
+    void     close_port(const std::string& port);
+    void     close_all();
     bool     open_port(const std::string& port, const std::string& description = "");
     bool     is_port_selected(const std::string& port);
     void     change_baud_rate(uint32_t baud);
@@ -45,14 +56,14 @@ class serial_manager_t {
     uint32_t get_baud_rate() { return baud_rate_; }
 
   private:
-    log_fn_t                               log_;
-    int                                    baud_rate_;
-    int                                    timeout_ms_;
-    std::map<std::string, serial::Serial*> ports_;
-    std::unordered_set<std::string>        chosen_ports_;
-    std::thread                            worker_;
-    std::vector<std::string>               input_stream_;
-    std::mutex                             mutex_;
+    log_fn_t                                                         log_;
+    int                                                              baud_rate_;
+    int                                                              timeout_ms_;
+    std::unordered_map<std::string, std::unique_ptr<serial::Serial>> ports_;
+    std::unordered_set<std::string>                                  chosen_ports_;
+    std::thread                                                      worker_;
+    std::vector<std::string>                                         input_stream_;
+    mutable std::recursive_mutex                                     mutex_;
 };
 
 } // namespace mbr

--- a/src/app/pages/serialmon.cpp
+++ b/src/app/pages/serialmon.cpp
@@ -53,11 +53,11 @@ void serial_page::draw_top_lhs() {
         }
         ImGui::Separator();
 
-        auto all_ports = context_->backend->serial_manager.export_ports();
+        auto all_ports = context_->backend->serial_manager.get_all_ports();
         ImGui::SetNextItemWidth(250.0F);
         if (ImGui::BeginCombo("##port_dropdown", "Select Ports to Send Data")) {
             const auto cleanup{gsl::finally(ImGui::EndCombo)};
-            for (auto& [port, ser] : all_ports) {
+            for (const auto& port : all_ports) {
                 const bool is_selected = context_->backend->serial_manager.is_port_selected(port);
                 if (ImGui::Selectable(
                         port.c_str(), is_selected, ImGuiSelectableFlags_NoAutoClosePopups)) {
@@ -75,7 +75,7 @@ void serial_page::draw_top_lhs() {
         ImGui::SameLine();
         ImGui::TextUnformatted("Chosen Ports: ");
         ImGui::SameLine();
-        for (const auto& port : context_->backend->serial_manager.return_chosen()) {
+        for (const auto& port : context_->backend->serial_manager.get_chosen_ports()) {
             ImGui::TextUnformatted(port.c_str());
             ImGui::SameLine();
         }

--- a/src/esp32/serial.cpp
+++ b/src/esp32/serial.cpp
@@ -78,6 +78,18 @@ std::vector<std::string> serial_manager_t::get_all_ports() const {
     return out;
 }
 
+// TODO(blake): Is a copy really what we want here?
+std::unordered_set<std::string> serial_manager_t::get_chosen_ports() const {
+    const std::scoped_lock lock{mutex_};
+    return chosen_ports_;
+}
+
+// TODO(blake): Is a copy really what we want here?
+std::vector<std::string> serial_manager_t::return_data_stream() const {
+    const std::scoped_lock lock{mutex_};
+    return input_stream_;
+}
+
 // Send Data to all selected Serial ports
 void serial_manager_t::send_data(const std::string& msg) {
     const std::scoped_lock   lock{mutex_};

--- a/src/esp32/serial.cpp
+++ b/src/esp32/serial.cpp
@@ -1,4 +1,5 @@
-#include <map>
+#include <exception>
+#include <memory>
 #include <string>
 #include <thread>
 #include <vector>
@@ -10,6 +11,8 @@
 using namespace std::chrono_literals;
 
 namespace mbr {
+
+serial_manager_t::~serial_manager_t() { stop(); }
 
 // Initializes and maintains Serial behavior
 void serial_manager_t::start() {
@@ -32,14 +35,13 @@ bool serial_manager_t::open_port(const std::string& port, const std::string& des
         timeout.read_timeout_multiplier  = 0;
         timeout.write_timeout_constant   = 0;
         timeout.write_timeout_multiplier = 0;
-        auto* ser                        = new serial::Serial(port, baud_rate_, timeout);
+        auto ser = std::make_unique<serial::Serial>(port, baud_rate_, timeout);
         if (ser->isOpen()) {
-            ports_[port] = ser;
+            ports_[port] = std::move(ser);
             log_info(log_, "[SerialManager] Opened: {}", port);
             if (!description.empty()) { log_info(log_, description); }
             return true;
         }
-        delete ser;
     } catch (const std::exception& e) {
         log_error(log_, "[SerialManager] Failed to open {}: {}", port, e.what());
     }
@@ -48,7 +50,7 @@ bool serial_manager_t::open_port(const std::string& port, const std::string& des
 
 // Close ports that have disappeared, open ports that have appeared
 void serial_manager_t::clean_ports() {
-    const std::scoped_lock<std::mutex>  lock{mutex_};
+    const std::scoped_lock              lock{mutex_};
     const std::vector<serial::PortInfo> available = serial::list_ports();
     for (const auto& info : available) {
         if (!ports_.contains(info.port)) { open_port(info.port, info.description); }
@@ -66,13 +68,23 @@ void serial_manager_t::clean_ports() {
     }
     for (const auto& port : to_remove) { close_port(port); }
 }
+
+// A deep copy of all of the stored port names
+std::vector<std::string> serial_manager_t::get_all_ports() const {
+    const std::scoped_lock   lock{mutex_};
+    std::vector<std::string> out;
+    out.reserve(ports_.size());
+    for (const auto& [port, _] : ports_) { out.emplace_back(port); }
+    return out;
+}
+
 // Send Data to all selected Serial ports
 void serial_manager_t::send_data(const std::string& msg) {
-    const std::scoped_lock<std::mutex> lock{mutex_};
-    std::vector<std::string>           failed;
+    const std::scoped_lock   lock{mutex_};
+    std::vector<std::string> failed;
     for (const auto& port : chosen_ports_) {
         auto it = ports_.find(port);
-        if (it == ports_.end() || it->second == nullptr) { continue; }
+        if (it == ports_.end() || !it->second) { continue; }
         try {
             it->second->write(msg);
         } catch (const std::exception& e) {
@@ -84,11 +96,11 @@ void serial_manager_t::send_data(const std::string& msg) {
 }
 
 void serial_manager_t::receive_data() {
-    const std::scoped_lock<std::mutex> lock{mutex_};
-    std::vector<std::string>           failed;
+    const std::scoped_lock   lock{mutex_};
+    std::vector<std::string> failed;
     for (const auto& port : chosen_ports_) {
         auto it = ports_.find(port);
-        if (it == ports_.end() || it->second == nullptr) { continue; }
+        if (it == ports_.end() || !it->second) { continue; }
         try {
             if (it->second->available() > 0) {
                 auto input = it->second->read(it->second->available());
@@ -103,26 +115,32 @@ void serial_manager_t::receive_data() {
 }
 // Close selected port
 void serial_manager_t::close_port(const std::string& port) {
-    auto it = ports_.find(port);
+    const std::scoped_lock lock{mutex_};
+    auto                   it = ports_.find(port);
     if (it == ports_.end()) { return; }
     it->second->close();
-    delete it->second;
     ports_.erase(it);
     if (chosen_ports_.contains(port)) { chosen_ports_.erase(port); }
     log_info(log_, "[SerialManager] Closed: {}", port);
 }
 // Close all ports
 void serial_manager_t::close_all() {
+    const std::scoped_lock lock{mutex_};
     for (auto& [port, ser] : ports_) {
-        ser->close();
+        try {
+            ser->close();
+        } catch (const std::exception& e) {
+            log_info(log_, "[SerialManager] Failed to close port {}: ", e.what());
+            continue;
+        }
         log_info(log_, "[SerialManager] Closed: {}", port);
-        delete ser;
     }
     ports_.clear();
     chosen_ports_.clear();
 }
 // change baud rate (its in the name)
 void serial_manager_t::change_baud_rate(uint32_t baud) {
+    const std::scoped_lock lock{mutex_};
     baud_rate_ =
         static_cast<int>(baud); // TODO(blake) why is m_BaudRate an int but this func takes a u32
     for (auto& [port, ser] : ports_) {
@@ -139,19 +157,23 @@ bool serial_manager_t::is_running() const { return worker_.joinable(); }
 void serial_manager_t::stop() {
     if (!worker_.joinable()) { return; }
     keep_running = false;
-    std::thread cleanup([worker = std::move(worker_), this]() mutable {
-        if (worker.joinable()) { worker.join(); }
-        close_all();
-    });
-    cleanup.detach();
+    worker_.join();
+    close_all();
 }
 
 bool serial_manager_t::is_port_selected(const std::string& port) {
+    const std::scoped_lock lock{mutex_};
     return chosen_ports_.contains(port);
 }
 
-void serial_manager_t::add_port(const std::string& port) { chosen_ports_.insert(port); }
+void serial_manager_t::add_port(const std::string& port) {
+    const std::scoped_lock lock{mutex_};
+    chosen_ports_.insert(port);
+}
 
-void serial_manager_t::remove_port(const std::string& port) { chosen_ports_.erase(port); }
+void serial_manager_t::remove_port(const std::string& port) {
+    const std::scoped_lock lock{mutex_};
+    chosen_ports_.erase(port);
+}
 
 } // namespace mbr


### PR DESCRIPTION
## Description

Update `serial` class to hold a recursive lock instead of a normal lock. This wasn't strictly necessary since you could instead use a well-managed unique lock, but this approach makes it simple for the scoped_lock usage in the manager. The serial manager now uses this lock correctly in the various critical sections of its logic to prevent data races. 

The shutdown logic has also been changed to occur synchronously instead of delegating to a detached thread. This ensures that the worker thread is fully shut down and joined before ports are modified or cleared, preventing data races and potential UB when starting a new thread immediately after stopping the old one.

Also switched `serial_manager` to store unique pointers instead of manual pointers managed with `new`/`delete` to prevent possible memory leaks.

Closes #35 

