### PR TITLE
Threading fixes

### DIFF
--- a/include/core/rw_latch.hpp
+++ b/include/core/rw_latch.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <shared_mutex>
+
+#include <stdx/utility.hh>
+
+#ifndef NDEBUG
+#    include <atomic>
+
+#    include <stdx/types.hh>
+#endif
+
+namespace mbr {
+
+// A thin wrapper over a shared mutex for instrumented latching
+class rw_latch {
+  public:
+    rw_latch() noexcept = default;
+    ~rw_latch()         = default;
+    MAKE_PINNED(rw_latch);
+
+    void               lock();
+    [[nodiscard]] bool try_lock();
+    void               unlock();
+
+    void               lock_shared();
+    [[nodiscard]] bool try_lock_shared();
+    void               unlock_shared();
+
+  private:
+    void note_exclusive_acquired() noexcept;
+    void note_exclusive_released() noexcept;
+    void note_shared_acquired() noexcept;
+    void note_shared_released() noexcept;
+
+  private:
+    std::shared_mutex mutex_;
+#ifndef NDEBUG
+    std::atomic<i32>  readers_{0};
+    std::atomic<bool> writer_{false};
+#endif
+};
+
+} // namespace mbr

--- a/include/esp32/backend.hpp
+++ b/include/esp32/backend.hpp
@@ -40,12 +40,7 @@ class telemetry_backend {
     void start();
     void kill();
     void send_cmd(const std::string& text);
-
-    // Returns a safely accessible grouping of relevant data.
-    //
-    // This automatically manages the Data's mutex!
-    [[nodiscard]] telemetry_data::packed_data pack_data();
-    void                                      set_ip(const ipv4_t& ipv4);
+    void set_ip(const ipv4_t& ipv4);
 
     [[nodiscard]] rw_latch&             get_data_latch() noexcept { return data_latch_; }
     [[nodiscard]] telemetry_data&       get_data() noexcept { return data_; }

--- a/include/esp32/backend.hpp
+++ b/include/esp32/backend.hpp
@@ -3,7 +3,6 @@
 #include <atomic>
 #include <chrono>
 #include <functional>
-#include <mutex>
 #include <string>
 #include <string_view>
 #include <thread>
@@ -18,6 +17,7 @@
 
 #include "core/ip.hpp"
 #include "core/log.hpp"
+#include "core/rw_latch.hpp"
 #include "esp32/data.hpp"
 #include "esp32/serial.hpp"
 
@@ -47,19 +47,28 @@ class telemetry_backend {
     [[nodiscard]] telemetry_data::packed_data pack_data();
     void                                      set_ip(const ipv4_t& ipv4);
 
-  private:
-    log_fn_t log_;
+    [[nodiscard]] rw_latch&             get_data_latch() noexcept { return data_latch_; }
+    [[nodiscard]] telemetry_data&       get_data() noexcept { return data_; }
+    [[nodiscard]] const telemetry_data& get_data() const noexcept { return data_; }
+    [[nodiscard]] serial_manager_t&     get_serial_manager() noexcept { return serial_manager_; }
 
-  public:
-    std::mutex        data_mutex;
-    telemetry_data    data;
-    serial_manager_t  serial_manager;
-    std::atomic<bool> try_connection{false};
-    std::atomic<bool> is_connected{false};
-    std::atomic<bool> is_logging{false};
-    std::atomic<bool> is_receiving{false};
-    std::atomic<bool> is_writing{false};
-    std::atomic<bool> is_open{false};
+    [[nodiscard]] std::atomic<bool>& get_try_connection() noexcept { return try_connection_; }
+
+    [[nodiscard]] bool is_connected() const noexcept {
+        return is_connected_.load(std::memory_order_relaxed);
+    }
+    [[nodiscard]] bool is_receiving() const noexcept {
+        return is_receiving_.load(std::memory_order_relaxed);
+    }
+    [[nodiscard]] bool is_writing() const noexcept {
+        return is_writing_.load(std::memory_order_relaxed);
+    }
+    [[nodiscard]] bool is_open() const noexcept { return is_open_.load(std::memory_order_relaxed); }
+
+    [[nodiscard]] bool is_logging() const noexcept {
+        return is_logging_.load(std::memory_order_relaxed);
+    }
+    void set_logging(bool value) noexcept { is_logging_.store(value, std::memory_order_relaxed); }
 
   private:
     void worker_loop();
@@ -71,12 +80,22 @@ class telemetry_backend {
     void register_handlers();
 
   private:
-    std::jthread                          worker_;
-    ix::WebSocket                         web_sockets_;
-    std::string                           buffer_;
-    ipv4_t                                ip_addr_;
-    std::chrono::steady_clock::time_point last_data_time_;
-    std::atomic<bool>                     should_kill_{false};
+    log_fn_t                                           log_;
+    rw_latch                                           data_latch_;
+    telemetry_data                                     data_;
+    serial_manager_t                                   serial_manager_;
+    std::atomic<bool>                                  try_connection_{false};
+    std::atomic<bool>                                  is_connected_{false};
+    std::atomic<bool>                                  is_logging_{false};
+    std::atomic<bool>                                  is_receiving_{false};
+    std::atomic<bool>                                  is_writing_{false};
+    std::atomic<bool>                                  is_open_{false};
+    std::atomic<bool>                                  should_kill_{false};
+    std::jthread                                       worker_;
+    ix::WebSocket                                      web_sockets_;
+    std::string                                        buffer_;
+    ipv4_t                                             ip_addr_;
+    std::atomic<std::chrono::steady_clock::time_point> last_data_time_;
 
     stdx::fixed::enum_map<response_type_t, std::function<void(std::string_view)>>
         response_handlers_;

--- a/include/esp32/data.hpp
+++ b/include/esp32/data.hpp
@@ -7,6 +7,7 @@
 #include <ankerl/unordered_dense.h>
 #include <nlohmann/json.hpp>
 #include <stdx/option.hh>
+#include <stdx/type_traits.hh>
 #include <stdx/types.hh>
 
 #include "core/log.hpp"
@@ -24,8 +25,6 @@ using json = nlohmann::json;
 
 class telemetry_data {
   public:
-
-
     struct data_info {
         std::string key;
         std::string name;
@@ -37,12 +36,10 @@ class telemetry_data {
 
   public:
     explicit telemetry_data(log_fn_t log = nullptr);
-    ~telemetry_data() = default;
 
-    std::vector<data_info>                                         data_values;
-    ankerl::unordered_dense::map<std::string, std::vector<double>> series;
-    [[nodiscard]] const std::vector<double>& get_time() const { return time_; }
-    [[nodiscard]] const std::vector<u64>&    get_time_no_normal() const {
+    std::vector<data_info>                data_values;
+    [[nodiscard]] const std::vector<f64>& get_time() const { return time_; }
+    [[nodiscard]] const std::vector<u64>& get_time_no_normal() const {
         return time_no_normal_micros_;
     }
 
@@ -50,6 +47,20 @@ class telemetry_data {
     [[nodiscard]] const stdx::option<local_time>& get_sync_lt() const { return sync_lt_; }
     [[nodiscard]] const std::string&              get_current_line() { return current_line_; }
 
+    template <typename Self>
+    [[nodiscard]] auto& get_series(this Self&& self, const std::string& key) noexcept {
+        auto it = self.series.find(key);
+        if (it != self.series.end()) { return it->second; }
+
+        if (!self.logged_missing_keys_.contains(key)) {
+            self.logged_missing_keys_.insert(key);
+            log_error(self.log_, "Key '{}' not found in telemetry configuration!", key);
+        }
+        static stdx::const_dispatch_t<Self, std::vector<f64>> dummy;
+        return dummy;
+    }
+
+    void set_sync_lt(local_time lt) noexcept { sync_lt_ = lt; }
     void write_data(const std::string& identifier, const std::string& value);
     void write_raw_line(const std::string& message);
     void save_current_line(const std::string& line);
@@ -60,13 +71,15 @@ class telemetry_data {
     void init_data();
 
   private:
-    log_fn_t                 log_;
-    std::string              current_line_;
-    std::vector<u64>         time_no_normal_micros_;
-    std::vector<double>      time_;
-    std::vector<std::string> raw_lines_;
-    double                   sync_start_;
-    stdx::option<local_time> sync_lt_;
+    log_fn_t                                                       log_;
+    std::string                                                    current_line_;
+    std::vector<u64>                                               time_no_normal_micros_;
+    std::vector<double>                                            time_;
+    std::vector<std::string>                                       raw_lines_;
+    double                                                         sync_start_;
+    stdx::option<local_time>                                       sync_lt_;
+    ankerl::unordered_dense::map<std::string, std::vector<double>> series;
+    mutable ankerl::unordered_dense::set<std::string>              logged_missing_keys_;
 
     friend class pages::view_page;
 };

--- a/include/esp32/data.hpp
+++ b/include/esp32/data.hpp
@@ -24,12 +24,7 @@ using json = nlohmann::json;
 
 class telemetry_data {
   public:
-    struct packed_data {
-        std::vector<u64>                                               time_micros_raw;
-        std::vector<double>                                            time_minutes_normalized;
-        ankerl::unordered_dense::map<std::string, std::vector<double>> series;
-        std::vector<std::string>                                       raw_lines;
-    };
+
 
     struct data_info {
         std::string key;

--- a/include/esp32/serial.hpp
+++ b/include/esp32/serial.hpp
@@ -46,13 +46,23 @@ class serial_manager_t {
     explicit serial_manager_t(baud_rate_t baud_rate  = baud_rate_t::ONEONEFIFTYTWO,
                               i32         timeout_ms = 0,
                               log_fn_t    log        = nullptr)
-        : log_{std::move(log)}, baud_rate_{baud_rate}, timeout_ms_{timeout_ms} {}
+        : log_{std::move(log)}, timeout_ms_{timeout_ms}, baud_rate_{baud_rate} {}
     ~serial_manager_t();
     MAKE_PINNED(serial_manager_t);
 
-    std::atomic<bool> keep_running{true};
-    std::atomic<bool> should_send_data{false};
-    std::atomic<bool> is_serial_write{false};
+    [[nodiscard]] bool should_send_data() const noexcept {
+        return should_send_data_.load(std::memory_order_relaxed);
+    }
+    void set_send_data(bool value) noexcept {
+        should_send_data_.store(value, std::memory_order_relaxed);
+    }
+
+    [[nodiscard]] bool is_serial_write() const noexcept {
+        return is_serial_write_.load(std::memory_order_relaxed);
+    }
+    void set_serial_write(bool value) noexcept {
+        is_serial_write_.store(value, std::memory_order_relaxed);
+    }
 
     [[nodiscard]] std::vector<std::string> get_all_ports() const;
     [[nodiscard]] chosen_port_set_t        get_chosen_ports() const;
@@ -76,8 +86,11 @@ class serial_manager_t {
 
   private:
     log_fn_t                     log_;
-    baud_rate_t                  baud_rate_;
     i32                          timeout_ms_;
+    baud_rate_t                  baud_rate_;
+    std::atomic<bool>            keep_running_{true};
+    std::atomic<bool>            should_send_data_{false};
+    std::atomic<bool>            is_serial_write_{false};
     port_map_t                   ports_;
     chosen_port_set_t            chosen_ports_;
     std::jthread                 worker_;

--- a/include/esp32/serial.hpp
+++ b/include/esp32/serial.hpp
@@ -64,9 +64,13 @@ class serial_manager_t {
         is_serial_write_.store(value, std::memory_order_relaxed);
     }
 
+    [[nodiscard]] std::recursive_mutex&           get_mutex() const noexcept { return mutex_; }
+    [[nodiscard]] const std::vector<std::string>& get_data_stream() const noexcept {
+        return input_stream_;
+    }
+
     [[nodiscard]] std::vector<std::string> get_all_ports() const;
     [[nodiscard]] chosen_port_set_t        get_chosen_ports() const;
-    [[nodiscard]] std::vector<std::string> return_data_stream() const;
 
     void        send_data(const std::string& msg);
     void        receive_data();

--- a/src/app/gui.cpp
+++ b/src/app/gui.cpp
@@ -149,7 +149,7 @@ void gui_t::on_frame() {
     }
 
     if (ImGui::IsKeyPressed(ImGuiKey_F11, false)) { sapp_toggle_fullscreen(); }
-    if (context_->backend->try_connection.exchange(false)) { context_->backend->start(); }
+    if (context_->backend->get_try_connection().exchange(false)) { context_->backend->start(); }
 }
 
 void gui_t::on_event(const sapp_event* event) { // NOLINT
@@ -220,14 +220,14 @@ void gui_t::draw_main_menu_bar() {
         if (ImGui::Button("Sync Time")) { context_->backend->send_cmd(command); }
 
         ImGui::Separator();
-        if (ImGui::Button("Restart Connection")) { context_->backend->try_connection = true; }
+        if (ImGui::Button("Restart Connection")) { context_->backend->get_try_connection() = true; }
         ImGui::Separator();
-        if (ImGui::Button("Clear Data")) { context_->backend->data.clear(); }
+        if (ImGui::Button("Clear Data")) { context_->backend->get_data().clear(); }
         ImGui::Separator();
 
         // Connection indicator
-        const bool connected = context_->backend->is_connected;
-        const bool receiving = context_->backend->is_receiving;
+        const bool connected = context_->backend->is_connected();
+        const bool receiving = context_->backend->is_receiving();
 
         const f32    radius = 10.0F;
         const ImVec2 pos    = ImGui::GetCursorScreenPos();

--- a/src/app/pages/home.cpp
+++ b/src/app/pages/home.cpp
@@ -78,10 +78,10 @@ void home_page::draw_top_lhs() {
         }
         ImGui::SameLine();
         ImGui::PushStyleColor(ImGuiCol_Button,
-                              context_->backend->is_writing ? ImVec4(0, 0.7F, 0, 1)
+                              context_->backend->is_writing() ? ImVec4(0, 0.7F, 0, 1)
                                                             : ImVec4(0.7F, 0, 0, 1));
-        if (ImGui::Button(context_->backend->is_writing ? "Write ON" : "Write OFF")) {
-            if (context_->backend->is_writing) {
+        if (ImGui::Button(context_->backend->is_writing() ? "Write ON" : "Write OFF")) {
+            if (context_->backend->is_writing()) {
                 context_->backend->send_cmd("SD_WRITE 0");
             } else {
                 context_->backend->send_cmd("SD_WRITE 1");
@@ -91,8 +91,8 @@ void home_page::draw_top_lhs() {
         ImGui::PopStyleColor();
         ImGui::SameLine();
         if (!sd_name_.empty()) {
-            if (ImGui::Button(context_->backend->is_open ? "Close SD" : "Open SD")) {
-                if (context_->backend->is_open) {
+            if (ImGui::Button(context_->backend->is_open() ? "Close SD" : "Open SD")) {
+                if (context_->backend->is_open()) {
                     context_->backend->send_cmd("SD_CLOSE");
                 } else {
                     const auto command = fmt::format("SD_START /{}.txt", sd_name_);
@@ -136,7 +136,7 @@ void home_page::draw_top_rhs() {
     ImGui::Separator();
 
     BOLD_DEFAULT(ImGui::SeparatorText("Metrics"));
-    ImGui::BulletText("Backend Status: %s", context_->backend->is_connected ? "Online" : "Offline");
+    ImGui::BulletText("Backend Status: %s", context_->backend->is_connected() ? "Online" : "Offline");
     ImGui::BulletText("Last IP Update: %s", previous_ip_.to_string().c_str());
     ImGui::BulletText("Application FPS: %.2f", ImGui::GetIO().Framerate);
 

--- a/src/app/pages/home.cpp
+++ b/src/app/pages/home.cpp
@@ -79,7 +79,7 @@ void home_page::draw_top_lhs() {
         ImGui::SameLine();
         ImGui::PushStyleColor(ImGuiCol_Button,
                               context_->backend->is_writing() ? ImVec4(0, 0.7F, 0, 1)
-                                                            : ImVec4(0.7F, 0, 0, 1));
+                                                              : ImVec4(0.7F, 0, 0, 1));
         if (ImGui::Button(context_->backend->is_writing() ? "Write ON" : "Write OFF")) {
             if (context_->backend->is_writing()) {
                 context_->backend->send_cmd("SD_WRITE 0");
@@ -136,7 +136,8 @@ void home_page::draw_top_rhs() {
     ImGui::Separator();
 
     BOLD_DEFAULT(ImGui::SeparatorText("Metrics"));
-    ImGui::BulletText("Backend Status: %s", context_->backend->is_connected() ? "Online" : "Offline");
+    ImGui::BulletText("Backend Status: %s",
+                      context_->backend->is_connected() ? "Online" : "Offline");
     ImGui::BulletText("Last IP Update: %s", previous_ip_.to_string().c_str());
     ImGui::BulletText("Application FPS: %.2f", ImGui::GetIO().Framerate);
 

--- a/src/app/pages/rpm.cpp
+++ b/src/app/pages/rpm.cpp
@@ -57,7 +57,7 @@ void rpm_page::DrawRHS(gsl::span<const f64> time,
                        gsl::span<const f64> engine) {
     if (ImGui::BeginChild("##graph")) {
         const auto cleanup_graph{gsl::finally(ImGui::EndChild)};
-        const auto sync_lt    = context_->backend->data.get_sync_lt();
+        const auto sync_lt    = context_->backend->get_data().get_sync_lt();
         const auto plot_title = sync_lt
                                     ? fmt::format("RPM Data from {}", sync_lt.value().to_string())
                                     : "No Synced Time";

--- a/src/app/pages/rpm.cpp
+++ b/src/app/pages/rpm.cpp
@@ -1,5 +1,6 @@
 #include "app/pages/rpm.hpp"
 
+#include <shared_mutex>
 #include <string>
 #include <vector>
 
@@ -26,12 +27,13 @@ void rpm_page::update() {
     if (ImGui::BeginTable(
             "##viewsplit", 2, ImGuiTableFlags_NoBordersInBody | ImGuiTableFlags_Resizable)) {
         const auto cleanup_split{gsl::finally(ImGui::EndTable)};
-        const auto data = context_->backend->pack_data();
+        const std::shared_lock lock{context_->backend->get_data_latch()};
+        const auto& data = context_->backend->get_data();
 
         ImGui::TableNextColumn();
-        DrawLHS(data.raw_lines);
+        DrawLHS(data.get_raw_lines());
         ImGui::TableNextColumn();
-        DrawRHS(data.time_minutes_normalized, data.series.at("W"), data.series.at("E"));
+        DrawRHS(data.get_time(), data.series.at("W"), data.series.at("E"));
     }
 }
 

--- a/src/app/pages/rpm.cpp
+++ b/src/app/pages/rpm.cpp
@@ -26,14 +26,14 @@ void rpm_page::update() {
     PROFILE_FUNCTION();
     if (ImGui::BeginTable(
             "##viewsplit", 2, ImGuiTableFlags_NoBordersInBody | ImGuiTableFlags_Resizable)) {
-        const auto cleanup_split{gsl::finally(ImGui::EndTable)};
+        const auto             cleanup_split{gsl::finally(ImGui::EndTable)};
         const std::shared_lock lock{context_->backend->get_data_latch()};
-        const auto& data = context_->backend->get_data();
+        const auto&            data = context_->backend->get_data();
 
         ImGui::TableNextColumn();
         DrawLHS(data.get_raw_lines());
         ImGui::TableNextColumn();
-        DrawRHS(data.get_time(), data.series.at("W"), data.series.at("E"));
+        DrawRHS(data.get_time(), data.get_series("W"), data.get_series("E"));
     }
 }
 

--- a/src/app/pages/serialmon.cpp
+++ b/src/app/pages/serialmon.cpp
@@ -58,7 +58,8 @@ void serial_page::draw_top_lhs() {
         ImGui::SameLine();
         text_drawer_.send_data_button();
         if (context_->backend->get_serial_manager().should_send_data()) {
-            context_->backend->get_serial_manager().send_data(context_->backend->get_data().get_current_line());
+            context_->backend->get_serial_manager().send_data(
+                context_->backend->get_data().get_current_line());
         }
         ImGui::Separator();
 
@@ -67,7 +68,8 @@ void serial_page::draw_top_lhs() {
         if (ImGui::BeginCombo("##port_dropdown", "Select Ports to Send Data")) {
             const auto cleanup{gsl::finally(ImGui::EndCombo)};
             for (const auto& port : all_ports) {
-                const bool is_selected = context_->backend->get_serial_manager().is_port_selected(port);
+                const bool is_selected =
+                    context_->backend->get_serial_manager().is_port_selected(port);
                 if (ImGui::Selectable(
                         port.c_str(), is_selected, ImGuiSelectableFlags_NoAutoClosePopups)) {
                     if (!is_selected) {
@@ -135,7 +137,8 @@ void serial_page::draw_bottom() {
     if (ImGui::BeginChild("##datalog")) {
         const auto cleanup{gsl::finally(ImGui::EndChild)};
         ImGui::Separator();
-        utils::draw_data_log(context_->backend->get_serial_manager().return_data_stream());
+        const std::scoped_lock lock{context_->backend->get_serial_manager().get_mutex()};
+        utils::draw_data_log(context_->backend->get_serial_manager().get_data_stream());
     }
 }
 

--- a/src/app/pages/serialmon.cpp
+++ b/src/app/pages/serialmon.cpp
@@ -57,7 +57,7 @@ void serial_page::draw_top_lhs() {
         }
         ImGui::SameLine();
         text_drawer_.send_data_button();
-        if (context_->backend->get_serial_manager().should_send_data) {
+        if (context_->backend->get_serial_manager().should_send_data()) {
             context_->backend->get_serial_manager().send_data(context_->backend->get_data().get_current_line());
         }
         ImGui::Separator();

--- a/src/app/pages/serialmon.cpp
+++ b/src/app/pages/serialmon.cpp
@@ -49,32 +49,32 @@ void serial_page::draw_top_lhs() {
 
         ImGui::Separator();
         if (text_drawer_.start_serial_button()) {
-            if (!context_->backend->serial_manager.is_running()) {
-                context_->backend->serial_manager.start();
+            if (!context_->backend->get_serial_manager().is_running()) {
+                context_->backend->get_serial_manager().start();
             } else {
-                context_->backend->serial_manager.stop();
+                context_->backend->get_serial_manager().stop();
             }
         }
         ImGui::SameLine();
         text_drawer_.send_data_button();
-        if (context_->backend->serial_manager.should_send_data) {
-            context_->backend->serial_manager.send_data(context_->backend->data.get_current_line());
+        if (context_->backend->get_serial_manager().should_send_data) {
+            context_->backend->get_serial_manager().send_data(context_->backend->get_data().get_current_line());
         }
         ImGui::Separator();
 
-        auto all_ports = context_->backend->serial_manager.get_all_ports();
+        auto all_ports = context_->backend->get_serial_manager().get_all_ports();
         ImGui::SetNextItemWidth(250.0F);
         if (ImGui::BeginCombo("##port_dropdown", "Select Ports to Send Data")) {
             const auto cleanup{gsl::finally(ImGui::EndCombo)};
             for (const auto& port : all_ports) {
-                const bool is_selected = context_->backend->serial_manager.is_port_selected(port);
+                const bool is_selected = context_->backend->get_serial_manager().is_port_selected(port);
                 if (ImGui::Selectable(
                         port.c_str(), is_selected, ImGuiSelectableFlags_NoAutoClosePopups)) {
                     if (!is_selected) {
-                        context_->backend->serial_manager.add_port(port);
+                        context_->backend->get_serial_manager().add_port(port);
                         log_info(context_->log, "Added port {}", port);
                     } else {
-                        context_->backend->serial_manager.remove_port(port);
+                        context_->backend->get_serial_manager().remove_port(port);
                         log_info(context_->log, "Removed port {}", port);
                     }
                 }
@@ -84,7 +84,7 @@ void serial_page::draw_top_lhs() {
         ImGui::SameLine();
         ImGui::TextUnformatted("Chosen Ports: ");
         ImGui::SameLine();
-        for (const auto& port : context_->backend->serial_manager.get_chosen_ports()) {
+        for (const auto& port : context_->backend->get_serial_manager().get_chosen_ports()) {
             ImGui::TextUnformatted(port.c_str());
             ImGui::SameLine();
         }
@@ -95,13 +95,13 @@ void serial_page::draw_top_lhs() {
         ImGui::SetNextItemWidth(100.0F);
         if (ImGui::BeginCombo(
                 "##baud_dropdown",
-                baud_rate_string(context_->backend->serial_manager.get_baud_rate()))) {
+                baud_rate_string(context_->backend->get_serial_manager().get_baud_rate()))) {
             const auto cleanup_combo{gsl::finally(ImGui::EndCombo)};
             for (const auto rate : stdx::enum_range<baud_rate_t>()) {
                 const bool is_selected =
-                    (context_->backend->serial_manager.get_baud_rate() == rate);
+                    (context_->backend->get_serial_manager().get_baud_rate() == rate);
                 if (ImGui::Selectable(baud_rate_string(rate), is_selected)) {
-                    context_->backend->serial_manager.change_baud_rate(rate);
+                    context_->backend->get_serial_manager().change_baud_rate(rate);
                 }
                 if (is_selected) { ImGui::SetItemDefaultFocus(); }
             }
@@ -128,14 +128,14 @@ void serial_page::draw_bottom() {
                               "Send Serial Data Here",
                               1900.0F,
                               ImGuiInputTextFlags_EnterReturnsTrue)) {
-        context_->backend->serial_manager.send_data(serial_buffer_ + "\n");
+        context_->backend->get_serial_manager().send_data(serial_buffer_ + "\n");
         serial_buffer_ = {};
         ImGui::SetKeyboardFocusHere(-1);
     }
     if (ImGui::BeginChild("##datalog")) {
         const auto cleanup{gsl::finally(ImGui::EndChild)};
         ImGui::Separator();
-        utils::draw_data_log(context_->backend->serial_manager.return_data_stream());
+        utils::draw_data_log(context_->backend->get_serial_manager().return_data_stream());
     }
 }
 

--- a/src/app/pages/shock.cpp
+++ b/src/app/pages/shock.cpp
@@ -1,5 +1,6 @@
 #include "app/pages/shock.hpp"
 
+#include <shared_mutex>
 #include <string>
 #include <vector>
 
@@ -25,12 +26,13 @@ void shock_page::update() {
     if (ImGui::BeginTable(
             "##viewsplit", 2, ImGuiTableFlags_NoBordersInBody | ImGuiTableFlags_Resizable)) {
         const auto cleanup_split{gsl::finally(ImGui::EndTable)};
-        const auto data = context_->backend->pack_data();
+        const std::shared_lock lock{context_->backend->get_data_latch()};
+        const auto& data = context_->backend->get_data();
 
         ImGui::TableNextColumn();
-        draw_lhs(data.raw_lines);
+        draw_lhs(data.get_raw_lines());
         ImGui::TableNextColumn();
-        draw_rhs(data.time_minutes_normalized,
+        draw_rhs(data.get_time(),
                  data.series.at("FR"),
                  data.series.at("FL"),
                  data.series.at("RR"),

--- a/src/app/pages/shock.cpp
+++ b/src/app/pages/shock.cpp
@@ -25,18 +25,18 @@ void shock_page::update() {
     PROFILE_FUNCTION();
     if (ImGui::BeginTable(
             "##viewsplit", 2, ImGuiTableFlags_NoBordersInBody | ImGuiTableFlags_Resizable)) {
-        const auto cleanup_split{gsl::finally(ImGui::EndTable)};
+        const auto             cleanup_split{gsl::finally(ImGui::EndTable)};
         const std::shared_lock lock{context_->backend->get_data_latch()};
-        const auto& data = context_->backend->get_data();
+        const auto&            data = context_->backend->get_data();
 
         ImGui::TableNextColumn();
         draw_lhs(data.get_raw_lines());
         ImGui::TableNextColumn();
         draw_rhs(data.get_time(),
-                 data.series.at("FR"),
-                 data.series.at("FL"),
-                 data.series.at("RR"),
-                 data.series.at("RL"));
+                 data.get_series("FR"),
+                 data.get_series("FL"),
+                 data.get_series("RR"),
+                 data.get_series("RL"));
     }
 }
 

--- a/src/app/pages/shock.cpp
+++ b/src/app/pages/shock.cpp
@@ -62,7 +62,7 @@ void shock_page::draw_rhs(gsl::span<const f64> time,
                           gsl::span<const f64> bl) {
     if (ImGui::BeginChild("##graph")) {
         const auto cleanup_graph{gsl::finally(ImGui::EndChild)};
-        const auto sync_lt = context_->backend->data.get_sync_lt();
+        const auto sync_lt = context_->backend->get_data().get_sync_lt();
         const auto plot_title =
             sync_lt ? fmt::format("Shock Travel Data from {}", sync_lt.value().to_string())
                     : "No Synced Time";

--- a/src/app/pages/utils.cpp
+++ b/src/app/pages/utils.cpp
@@ -35,10 +35,10 @@ void text_drawers::start_logging_button() {
 bool text_drawers::start_serial_button() {
     bool clicked = false;
     HEADER({
-        if (ImGui::Button(context_->backend->get_serial_manager().is_serial_write ? "Stop Serial"
+        if (ImGui::Button(context_->backend->get_serial_manager().is_serial_write() ? "Stop Serial"
                                                                             : "Start Serial")) {
-            context_->backend->get_serial_manager().is_serial_write =
-                !context_->backend->get_serial_manager().is_serial_write;
+            context_->backend->get_serial_manager().set_serial_write(
+                !context_->backend->get_serial_manager().is_serial_write());
             clicked = true;
         }
     });
@@ -47,10 +47,10 @@ bool text_drawers::start_serial_button() {
 
 void text_drawers::send_data_button() {
     HEADER({
-        if (ImGui::Button(context_->backend->get_serial_manager().should_send_data ? "Stop Data Send"
+        if (ImGui::Button(context_->backend->get_serial_manager().should_send_data() ? "Stop Data Send"
                                                                              : "Send Data")) {
-            context_->backend->get_serial_manager().should_send_data =
-                !context_->backend->get_serial_manager().should_send_data;
+            context_->backend->get_serial_manager().set_send_data(
+                !context_->backend->get_serial_manager().should_send_data());
         }
     });
 }

--- a/src/app/pages/utils.cpp
+++ b/src/app/pages/utils.cpp
@@ -35,8 +35,9 @@ void text_drawers::start_logging_button() {
 bool text_drawers::start_serial_button() {
     bool clicked = false;
     HEADER({
-        if (ImGui::Button(context_->backend->get_serial_manager().is_serial_write() ? "Stop Serial"
-                                                                            : "Start Serial")) {
+        if (ImGui::Button(context_->backend->get_serial_manager().is_serial_write()
+                              ? "Stop Serial"
+                              : "Start Serial")) {
             context_->backend->get_serial_manager().set_serial_write(
                 !context_->backend->get_serial_manager().is_serial_write());
             clicked = true;
@@ -47,8 +48,9 @@ bool text_drawers::start_serial_button() {
 
 void text_drawers::send_data_button() {
     HEADER({
-        if (ImGui::Button(context_->backend->get_serial_manager().should_send_data() ? "Stop Data Send"
-                                                                             : "Send Data")) {
+        if (ImGui::Button(context_->backend->get_serial_manager().should_send_data()
+                              ? "Stop Data Send"
+                              : "Send Data")) {
             context_->backend->get_serial_manager().set_send_data(
                 !context_->backend->get_serial_manager().should_send_data());
         }

--- a/src/app/pages/utils.cpp
+++ b/src/app/pages/utils.cpp
@@ -26,8 +26,8 @@ namespace mbr::pages::utils {
 
 void text_drawers::start_logging_button() {
     HEADER({
-        if (ImGui::Button(context_->backend->is_logging ? "Stop Logging" : "Start Logging")) {
-            context_->backend->is_logging = !context_->backend->is_logging;
+        if (ImGui::Button(context_->backend->is_logging() ? "Stop Logging" : "Start Logging")) {
+            context_->backend->set_logging(!context_->backend->is_logging());
         }
     });
 }
@@ -35,10 +35,10 @@ void text_drawers::start_logging_button() {
 bool text_drawers::start_serial_button() {
     bool clicked = false;
     HEADER({
-        if (ImGui::Button(context_->backend->serial_manager.is_serial_write ? "Stop Serial"
+        if (ImGui::Button(context_->backend->get_serial_manager().is_serial_write ? "Stop Serial"
                                                                             : "Start Serial")) {
-            context_->backend->serial_manager.is_serial_write =
-                !context_->backend->serial_manager.is_serial_write;
+            context_->backend->get_serial_manager().is_serial_write =
+                !context_->backend->get_serial_manager().is_serial_write;
             clicked = true;
         }
     });
@@ -47,10 +47,10 @@ bool text_drawers::start_serial_button() {
 
 void text_drawers::send_data_button() {
     HEADER({
-        if (ImGui::Button(context_->backend->serial_manager.should_send_data ? "Stop Data Send"
+        if (ImGui::Button(context_->backend->get_serial_manager().should_send_data ? "Stop Data Send"
                                                                              : "Send Data")) {
-            context_->backend->serial_manager.should_send_data =
-                !context_->backend->serial_manager.should_send_data;
+            context_->backend->get_serial_manager().should_send_data =
+                !context_->backend->get_serial_manager().should_send_data;
         }
     });
 }

--- a/src/app/pages/view.cpp
+++ b/src/app/pages/view.cpp
@@ -8,6 +8,7 @@
 #include <iterator>
 #include <memory>
 #include <mutex>
+#include <shared_mutex>
 #include <string>
 #include <thread>
 #include <utility>
@@ -322,7 +323,7 @@ void view_page::draw_rhs() {
 
         const auto data = context_->backend->pack_data();
 
-        const auto sync_lt    = context_->backend->data.get_sync_lt();
+        const auto sync_lt    = context_->backend->get_data().get_sync_lt();
         const auto plot_title = sync_lt
                                     ? fmt::format("Data View from {}", sync_lt.value().to_string())
                                     : "No Synced Time";
@@ -401,7 +402,7 @@ void view_page::draw_open_text() {
                     const std::scoped_lock<std::mutex> lock{txt_path_mutex_};
                     selected_txt_                 = path;
                     txt_dialog_running_           = false;
-                    context_->backend->is_logging = false;
+                    context_->backend->set_logging(false);
                 }
             } catch (const std::exception& e) {
                 txt_dialog_running_ = false;
@@ -439,8 +440,8 @@ void view_page::draw_sync_video_buttons() {
 
         stdx::option<usize> sync_time_pos;
         {
-            const std::scoped_lock<std::mutex> lock{context_->backend->data_mutex};
-            sync_time_pos = sync_data_video(context_->backend->data.get_time_no_normal());
+            const std::shared_lock lock{context_->backend->get_data_latch()};
+            sync_time_pos = sync_data_video(context_->backend->get_data().get_time_no_normal());
         }
 
         if (!sync_time_pos) {
@@ -505,10 +506,10 @@ void view_page::load_data() {
         return;
     }
 
-    const std::scoped_lock<std::mutex> lock{context_->backend->data_mutex};
-    context_->backend->data.clear();
+    const std::unique_lock lock{context_->backend->get_data_latch()};
+    context_->backend->get_data().clear();
     std::string ident, value;
-    while (file >> ident >> value) { context_->backend->data.write_data(ident, value); }
+    while (file >> ident >> value) { context_->backend->get_data().write_data(ident, value); }
 }
 
 void view_page::request_seek(i32 frame_index) {
@@ -688,15 +689,15 @@ stdx::option<usize> view_page::sync_data_video(const std::vector<u64>& micros_ti
 }
 
 void view_page::delete_extra(usize erase_pos) {
-    const std::scoped_lock<std::mutex> lock{context_->backend->data_mutex};
+    const std::unique_lock lock{context_->backend->get_data_latch()};
     std::vector<f64>* const            data[] = {
-        &context_->backend->data.time_,
-        &context_->backend->data.series.at("W"),
-        &context_->backend->data.series.at("E"),
-        &context_->backend->data.series.at("FR"),
-        &context_->backend->data.series.at("FL"),
-        &context_->backend->data.series.at("RR"),
-        &context_->backend->data.series.at("RL"),
+        &context_->backend->get_data().time_,
+        &context_->backend->get_data().series.at("W"),
+        &context_->backend->get_data().series.at("E"),
+        &context_->backend->get_data().series.at("FR"),
+        &context_->backend->get_data().series.at("FL"),
+        &context_->backend->get_data().series.at("RR"),
+        &context_->backend->get_data().series.at("RL"),
     };
 
     for (const auto& datum : data) {
@@ -710,10 +711,10 @@ void view_page::delete_extra(usize erase_pos) {
 
 void view_page::dynamic_plot_start() {
     if (dynamic_plotting_) {
-        const std::scoped_lock<std::mutex> lock{context_->backend->data_mutex};
-        const auto&                        time_vec = context_->backend->data.time_;
+        const std::shared_lock lock{context_->backend->get_data_latch()};
+        const auto&                        time_vec = context_->backend->get_data().time_;
         if (time_vec.empty()) { return; }
-        const auto begin_time_min = context_->backend->data.time_[0];
+        const auto begin_time_min = context_->backend->get_data().time_[0];
 
         const f64  target_end_time = begin_time_min + video_length_minutes_;
         const auto end_it          = std::ranges::lower_bound(time_vec, target_end_time);

--- a/src/app/pages/view.cpp
+++ b/src/app/pages/view.cpp
@@ -1,7 +1,6 @@
 #include "app/pages/view.hpp"
 
 #include <algorithm>
-#include <cstddef>
 #include <exception>
 #include <filesystem>
 #include <fstream>
@@ -322,7 +321,7 @@ void view_page::draw_rhs() {
         }
 
         const std::shared_lock lock{context_->backend->get_data_latch()};
-        const auto& data = context_->backend->get_data();
+        const auto&            data = context_->backend->get_data();
 
         const auto sync_lt    = data.get_sync_lt();
         const auto plot_title = sync_lt
@@ -334,38 +333,38 @@ void view_page::draw_rhs() {
             const auto cleanup_plot{gsl::finally(ImPlot::EndPlot)};
             utils::plot_if_non_empty<f64>("Wheel Speed",
                                           data.get_time(),
-                                          data.series.at("W"),
+                                          data.get_series("W"),
                                           data_show_ == data_view_t::ALL ||
                                               data_show_ == data_view_t::RPMDATA,
                                           plot_percent_);
             utils::plot_if_non_empty<f64>("Engine Speed",
                                           data.get_time(),
-                                          data.series.at("E"),
+                                          data.get_series("E"),
                                           data_show_ == data_view_t::ALL ||
                                               data_show_ == data_view_t::RPMDATA,
                                           plot_percent_);
 
             utils::plot_if_non_empty<f64>("Front Right Shock Travel",
                                           data.get_time(),
-                                          data.series.at("FR"),
+                                          data.get_series("FR"),
                                           data_show_ == data_view_t::ALL ||
                                               data_show_ == data_view_t::SHOCKDATA,
                                           plot_percent_);
             utils::plot_if_non_empty<f64>("Front Left Shock Travel",
                                           data.get_time(),
-                                          data.series.at("FL"),
+                                          data.get_series("FL"),
                                           data_show_ == data_view_t::ALL ||
                                               data_show_ == data_view_t::SHOCKDATA,
                                           plot_percent_);
             utils::plot_if_non_empty<f64>("Rear Right Shock Travel",
                                           data.get_time(),
-                                          data.series.at("RR"),
+                                          data.get_series("RR"),
                                           data_show_ == data_view_t::ALL ||
                                               data_show_ == data_view_t::SHOCKDATA,
                                           plot_percent_);
             utils::plot_if_non_empty<f64>("Rear Left Shock Travel",
                                           data.get_time(),
-                                          data.series.at("RL"),
+                                          data.get_series("RL"),
                                           data_show_ == data_view_t::ALL ||
                                               data_show_ == data_view_t::SHOCKDATA,
                                           plot_percent_);
@@ -401,8 +400,8 @@ void view_page::draw_open_text() {
                 const auto path = open_text_file(previous_path);
                 if (*alive) {
                     const std::scoped_lock<std::mutex> lock{txt_path_mutex_};
-                    selected_txt_                 = path;
-                    txt_dialog_running_           = false;
+                    selected_txt_       = path;
+                    txt_dialog_running_ = false;
                     context_->backend->set_logging(false);
                 }
             } catch (const std::exception& e) {
@@ -690,15 +689,15 @@ stdx::option<usize> view_page::sync_data_video(const std::vector<u64>& micros_ti
 }
 
 void view_page::delete_extra(usize erase_pos) {
-    const std::unique_lock lock{context_->backend->get_data_latch()};
-    std::vector<f64>* const            data[] = {
+    const std::unique_lock  lock{context_->backend->get_data_latch()};
+    std::vector<f64>* const data[] = {
         &context_->backend->get_data().time_,
-        &context_->backend->get_data().series.at("W"),
-        &context_->backend->get_data().series.at("E"),
-        &context_->backend->get_data().series.at("FR"),
-        &context_->backend->get_data().series.at("FL"),
-        &context_->backend->get_data().series.at("RR"),
-        &context_->backend->get_data().series.at("RL"),
+        &context_->backend->get_data().get_series("W"),
+        &context_->backend->get_data().get_series("E"),
+        &context_->backend->get_data().get_series("FR"),
+        &context_->backend->get_data().get_series("FL"),
+        &context_->backend->get_data().get_series("RR"),
+        &context_->backend->get_data().get_series("RL"),
     };
 
     for (const auto& datum : data) {
@@ -706,14 +705,14 @@ void view_page::delete_extra(usize erase_pos) {
     }
 
     for (const auto& datum : data) {
-        datum->erase(datum->begin(), datum->begin() + static_cast<ptrdiff_t>(erase_pos));
+        datum->erase(datum->begin(), datum->begin() + static_cast<idiff>(erase_pos));
     }
 }
 
 void view_page::dynamic_plot_start() {
     if (dynamic_plotting_) {
         const std::shared_lock lock{context_->backend->get_data_latch()};
-        const auto&                        time_vec = context_->backend->get_data().time_;
+        const auto&            time_vec = context_->backend->get_data().time_;
         if (time_vec.empty()) { return; }
         const auto begin_time_min = context_->backend->get_data().time_[0];
 

--- a/src/app/pages/view.cpp
+++ b/src/app/pages/view.cpp
@@ -321,9 +321,10 @@ void view_page::draw_rhs() {
             }
         }
 
-        const auto data = context_->backend->pack_data();
+        const std::shared_lock lock{context_->backend->get_data_latch()};
+        const auto& data = context_->backend->get_data();
 
-        const auto sync_lt    = context_->backend->get_data().get_sync_lt();
+        const auto sync_lt    = data.get_sync_lt();
         const auto plot_title = sync_lt
                                     ? fmt::format("Data View from {}", sync_lt.value().to_string())
                                     : "No Synced Time";
@@ -332,38 +333,38 @@ void view_page::draw_rhs() {
         if (ImPlot::BeginPlot(plot_title.c_str(), {-1, -1})) {
             const auto cleanup_plot{gsl::finally(ImPlot::EndPlot)};
             utils::plot_if_non_empty<f64>("Wheel Speed",
-                                          data.time_minutes_normalized,
+                                          data.get_time(),
                                           data.series.at("W"),
                                           data_show_ == data_view_t::ALL ||
                                               data_show_ == data_view_t::RPMDATA,
                                           plot_percent_);
             utils::plot_if_non_empty<f64>("Engine Speed",
-                                          data.time_minutes_normalized,
+                                          data.get_time(),
                                           data.series.at("E"),
                                           data_show_ == data_view_t::ALL ||
                                               data_show_ == data_view_t::RPMDATA,
                                           plot_percent_);
 
             utils::plot_if_non_empty<f64>("Front Right Shock Travel",
-                                          data.time_minutes_normalized,
+                                          data.get_time(),
                                           data.series.at("FR"),
                                           data_show_ == data_view_t::ALL ||
                                               data_show_ == data_view_t::SHOCKDATA,
                                           plot_percent_);
             utils::plot_if_non_empty<f64>("Front Left Shock Travel",
-                                          data.time_minutes_normalized,
+                                          data.get_time(),
                                           data.series.at("FL"),
                                           data_show_ == data_view_t::ALL ||
                                               data_show_ == data_view_t::SHOCKDATA,
                                           plot_percent_);
             utils::plot_if_non_empty<f64>("Rear Right Shock Travel",
-                                          data.time_minutes_normalized,
+                                          data.get_time(),
                                           data.series.at("RR"),
                                           data_show_ == data_view_t::ALL ||
                                               data_show_ == data_view_t::SHOCKDATA,
                                           plot_percent_);
             utils::plot_if_non_empty<f64>("Rear Left Shock Travel",
-                                          data.time_minutes_normalized,
+                                          data.get_time(),
                                           data.series.at("RL"),
                                           data_show_ == data_view_t::ALL ||
                                               data_show_ == data_view_t::SHOCKDATA,

--- a/src/core/rw_latch.cpp
+++ b/src/core/rw_latch.cpp
@@ -1,0 +1,75 @@
+#include "core/rw_latch.hpp"
+
+#include <stdx/profiler.hh>
+
+#ifndef NDEBUG
+#    include <stdx/assert.hh>
+#endif
+
+namespace mbr {
+
+void rw_latch::lock() {
+    {
+        PROFILE_SCOPE("rw_latch::lock");
+        mutex_.lock();
+    }
+    note_exclusive_acquired();
+}
+
+bool rw_latch::try_lock() {
+    if (!mutex_.try_lock()) { return false; }
+    note_exclusive_acquired();
+    return true;
+}
+
+void rw_latch::unlock() {
+    note_exclusive_released();
+    mutex_.unlock();
+}
+
+void rw_latch::lock_shared() {
+    {
+        PROFILE_SCOPE("rw_latch::lock_shared");
+        mutex_.lock_shared();
+    }
+    note_shared_acquired();
+}
+
+bool rw_latch::try_lock_shared() {
+    if (!mutex_.try_lock_shared()) { return false; }
+    note_shared_acquired();
+    return true;
+}
+
+void rw_latch::unlock_shared() {
+    note_shared_released();
+    mutex_.unlock_shared();
+}
+
+void rw_latch::note_exclusive_acquired() noexcept {
+#ifndef NDEBUG
+    ASSERT(readers_.load() == 0, "exclusive lock acquired while readers present");
+    ASSERT(!writer_.exchange(true), "exclusive lock acquired while already write-held");
+#endif
+}
+
+void rw_latch::note_exclusive_released() noexcept {
+#ifndef NDEBUG
+    ASSERT(writer_.exchange(false), "exclusive unlock without a matching lock");
+#endif
+}
+
+void rw_latch::note_shared_acquired() noexcept {
+#ifndef NDEBUG
+    ASSERT(!writer_.load(), "shared lock acquired while write-held");
+    readers_.fetch_add(1);
+#endif
+}
+
+void rw_latch::note_shared_released() noexcept {
+#ifndef NDEBUG
+    ASSERT(readers_.fetch_sub(1) > 0, "shared unlock without a matching lock");
+#endif
+}
+
+} // namespace mbr

--- a/src/esp32/backend.cpp
+++ b/src/esp32/backend.cpp
@@ -5,7 +5,6 @@
 #include <charconv>
 #include <chrono>
 #include <mutex>
-#include <shared_mutex>
 #include <string>
 #include <string_view>
 #include <system_error>
@@ -222,13 +221,6 @@ telemetry_backend::validate_packet(std::string_view str) const {
     return parsed;
 }
 
-telemetry_data::packed_data telemetry_backend::pack_data() {
-    const std::shared_lock lock{data_latch_};
-    return {.time_micros_raw         = data_.get_time_no_normal(),
-            .time_minutes_normalized = data_.get_time(),
-            .series                  = data_.series,
-            .raw_lines               = data_.get_raw_lines()};
-}
 
 void telemetry_backend::set_ip(const ipv4_t& ipv4) {
     if (!ipv4.is_valid()) {

--- a/src/esp32/backend.cpp
+++ b/src/esp32/backend.cpp
@@ -221,7 +221,6 @@ telemetry_backend::validate_packet(std::string_view str) const {
     return parsed;
 }
 
-
 void telemetry_backend::set_ip(const ipv4_t& ipv4) {
     if (!ipv4.is_valid()) {
         log_error(log_, "Requested Ip was invalid: {}", ipv4.to_string());
@@ -295,6 +294,7 @@ void telemetry_backend::register_handlers() {
         std::from_chars(line.data(), line.data() + line.size(), micros);
         local_time t{micros};
         log_info(log_, "Time successfully synced at: {}", t.to_string(false));
+        data_.set_sync_lt(t);
     };
 
     response_handlers_[response_type_t::SDSTART] = [this](std::string_view line) {

--- a/src/esp32/backend.cpp
+++ b/src/esp32/backend.cpp
@@ -5,6 +5,7 @@
 #include <charconv>
 #include <chrono>
 #include <mutex>
+#include <shared_mutex>
 #include <string>
 #include <string_view>
 #include <system_error>
@@ -39,7 +40,7 @@ using namespace std::chrono_literals;
 namespace mbr {
 
 telemetry_backend::telemetry_backend(log_fn_t log)
-    : log_{std::move(log)}, data{log_}, serial_manager{baud_rate_t::ONEONEFIFTYTWO, 500, log_} {
+    : log_{std::move(log)}, data_{log_}, serial_manager_{baud_rate_t::ONEONEFIFTYTWO, 500, log_} {
     buffer_.reserve(4'096);
     register_handlers();
 }
@@ -64,16 +65,16 @@ void telemetry_backend::start() {
 
     web_sockets_.setOnMessageCallback([this](const ix::WebSocketMessagePtr& msg) {
         if (msg->type == ix::WebSocketMessageType::Open) {
-            is_connected = true;
-            is_receiving = false;
+            is_connected_ = true;
+            is_receiving_ = false;
             send_cmd("STATUS");
             log_info(log_, "Connected to ESP32");
         }
 
         if (msg->type == ix::WebSocketMessageType::Close ||
             msg->type == ix::WebSocketMessageType::Error) {
-            is_connected = false;
-            is_receiving = false;
+            is_connected_ = false;
+            is_receiving_ = false;
         }
         if (msg->type == ix::WebSocketMessageType::Close) { log_warn(log_, "WebSocket closed"); }
 
@@ -83,7 +84,7 @@ void telemetry_backend::start() {
         }
 
         if (msg->type == ix::WebSocketMessageType::Message) {
-            is_receiving = true;
+            is_receiving_ = true;
             this->on_message(msg);
             last_data_time_ = std::chrono::steady_clock::now();
         }
@@ -106,7 +107,7 @@ void telemetry_backend::send_cmd(const std::string& text) {
         const ix::WebSocketSendInfo info = web_sockets_.send(text);
         if (!info.success) {
             log_warn(log_, "Send failed:");
-            is_connected = false;
+            is_connected_ = false;
             return;
         }
 
@@ -120,8 +121,10 @@ void telemetry_backend::send_cmd(const std::string& text) {
 void telemetry_backend::worker_loop() {
     while (!should_kill_) {
         std::this_thread::sleep_for(10ms);
-        if (web_sockets_.getReadyState() != ix::ReadyState::Open) { is_connected = false; }
-        if (std::chrono::steady_clock::now() - last_data_time_ > 500ms) { is_receiving = false; }
+        if (web_sockets_.getReadyState() != ix::ReadyState::Open) { is_connected_ = false; }
+        if (std::chrono::steady_clock::now() - last_data_time_.load() > 500ms) {
+            is_receiving_ = false;
+        }
     }
 }
 
@@ -144,18 +147,18 @@ void telemetry_backend::on_message(const ix::WebSocketMessagePtr& msg) {
             if (!parsed) { continue; }
 
             // Now we can safely unpack the packet
-            const std::scoped_lock<std::mutex> lock{data_mutex};
+            const std::unique_lock lock{data_latch_};
 
             // write data
-            if (!is_logging) { continue; }
+            if (!is_logging_) { continue; }
 
             for (const auto& [ident, value] : parsed.value()) {
-                data.write_data(std::string{ident}, std::string{value});
+                data_.write_data(std::string{ident}, std::string{value});
             }
-            data.write_raw_line(line);
+            data_.write_raw_line(line);
             for (const auto& [ident, value] : parsed.value()) {
                 if (ident == "W") {
-                    data.save_current_line(line);
+                    data_.save_current_line(line);
                     break;
                 }
             }
@@ -170,7 +173,7 @@ stdx::option<std::vector<std::pair<std::string_view, std::string_view>>>
 telemetry_backend::validate_packet(std::string_view str) const {
     PROFILE_FUNCTION();
     std::vector<std::pair<std::string_view, std::string_view>> parsed;
-    parsed.reserve(data.data_values.size());
+    parsed.reserve(data_.data_values.size());
 
     // runs through the whole sent packet. this ensures that the packet must be valid but doesn't
     // need every m_packetfield.
@@ -199,7 +202,7 @@ telemetry_backend::validate_packet(std::string_view str) const {
 
         // Validate the key is actually allowed
         const auto valid_key =
-            std::ranges::any_of(data.data_values, [&](const auto& dv) { return dv.key == key; });
+            std::ranges::any_of(data_.data_values, [&](const auto& dv) { return dv.key == key; });
         if (!valid_key) { return stdx::none; }
 
         // Validate timestamp field "T" is numeric
@@ -220,11 +223,11 @@ telemetry_backend::validate_packet(std::string_view str) const {
 }
 
 telemetry_data::packed_data telemetry_backend::pack_data() {
-    const std::scoped_lock<std::mutex> lock{data_mutex};
-    return {.time_micros_raw         = data.get_time_no_normal(),
-            .time_minutes_normalized = data.get_time(),
-            .series                  = data.series,
-            .raw_lines               = data.get_raw_lines()};
+    const std::shared_lock lock{data_latch_};
+    return {.time_micros_raw         = data_.get_time_no_normal(),
+            .time_minutes_normalized = data_.get_time(),
+            .series                  = data_.series,
+            .raw_lines               = data_.get_raw_lines()};
 }
 
 void telemetry_backend::set_ip(const ipv4_t& ipv4) {
@@ -237,7 +240,7 @@ void telemetry_backend::set_ip(const ipv4_t& ipv4) {
     kill();
     should_kill_ = false;
     start();
-    try_connection = false;
+    try_connection_ = false;
 }
 
 namespace {
@@ -307,23 +310,23 @@ void telemetry_backend::register_handlers() {
             log_error(log_, "SD Card Failed Initialization");
         } else {
             log_info(log_, "SD Card Initialized At {}", line);
-            is_open = true;
+            is_open_ = true;
         }
     };
 
     response_handlers_[response_type_t::SDWRITE] = [this](std::string_view line) {
         if (line == "1") {
             log_info(log_, "SD Card Has Begun Writing");
-            is_writing = true;
+            is_writing_ = true;
         } else if (line == "0") {
             log_info(log_, "SD Card Has Stopped Writing");
-            is_writing = false;
+            is_writing_ = false;
         }
     };
 
     response_handlers_[response_type_t::SDCLOSE] = [this](std::string_view line) {
         if (line == "1") {
-            is_open = false;
+            is_open_ = false;
             log_info(log_, "SD Card Has Closed Succesfully");
         } else if (line == "0") {
             log_info(log_, "SD Card Failed Close");

--- a/src/esp32/data.cpp
+++ b/src/esp32/data.cpp
@@ -1,13 +1,19 @@
 #include "esp32/data.hpp"
 
+#include <charconv>
 #include <exception>
 #include <fstream>
 #include <string>
+#include <string_view>
+#include <system_error>
 #include <utility>
 #include <vector>
 
-#include "core/log.hpp"
 #include <stdx/profiler.hh>
+#include <stdx/types.hh>
+
+#include "core/log.hpp"
+#include "core/time.hpp"
 
 namespace mbr {
 
@@ -47,9 +53,22 @@ void telemetry_data::init_data() {
 void telemetry_data::write_data(const std::string& identifier, const std::string& value) {
     PROFILE_FUNCTION();
     try {
-        f64 val = std::stod(value);
+        f64 val;
+        {
+            std::string_view to_parse{value};
+            auto             res = std::from_chars(to_parse.begin(), to_parse.end(), val);
+            if (res.ec != std::errc{} || res.ptr != to_parse.end()) {
+                return log_error(log_, "Failed to parse data into an f64");
+            }
+        }
+
         series[identifier].emplace_back(val);
-    } catch (const std::exception& e) { log_error(log_, "Couldn't write to existng data vector"); }
+        if (identifier == "T") {
+            u64 raw_micros = static_cast<u64>(val);
+            time_no_normal_micros_.emplace_back(raw_micros);
+            time_.emplace_back(local_time{raw_micros}.minutes_since_midnight());
+        }
+    } catch (const std::exception& e) { log_error(log_, "Couldn't write to existing data vector"); }
 }
 
 void telemetry_data::clear() {
@@ -59,6 +78,7 @@ void telemetry_data::clear() {
     raw_lines_.clear();
     current_line_.clear();
     sync_lt_.reset();
+    logged_missing_keys_.clear();
 }
 
 void telemetry_data::save_current_line(const std::string& line) { current_line_ = line; }

--- a/src/esp32/serial.cpp
+++ b/src/esp32/serial.cpp
@@ -56,7 +56,7 @@ serial_manager_t::~serial_manager_t() { stop(); }
 void serial_manager_t::start() {
     if (worker_.joinable()) { return; }
     keep_running_ = true;
-    worker_      = std::jthread([this]() {
+    worker_       = std::jthread([this]() {
         while (keep_running_) {
             this->clean_ports();
             std::this_thread::sleep_for(1s);
@@ -123,12 +123,6 @@ serial_manager_t::chosen_port_set_t serial_manager_t::get_chosen_ports() const {
     return chosen_ports_;
 }
 
-// TODO(blake): Is a copy really what we want here?
-std::vector<std::string> serial_manager_t::return_data_stream() const {
-    const std::scoped_lock lock{mutex_};
-    return input_stream_;
-}
-
 // Send Data to all selected Serial ports
 void serial_manager_t::send_data(const std::string& msg) {
     const std::scoped_lock   lock{mutex_};
@@ -157,6 +151,11 @@ void serial_manager_t::receive_data() {
             if (it->second->available() > 0) {
                 auto input = it->second->read(it->second->available());
                 input_stream_.push_back(input);
+                if (input_stream_.size() > 1'000) {
+                    input_stream_.erase(input_stream_.begin(),
+                                        input_stream_.begin() +
+                                            static_cast<idiff>(input_stream_.size() - 1'000));
+                }
             }
         } catch (const std::exception& e) {
             log_error(log_, "[SerialManager] Read failed on {}: {}", port, e.what());

--- a/src/esp32/serial.cpp
+++ b/src/esp32/serial.cpp
@@ -1,5 +1,6 @@
 #include "esp32/serial.hpp"
 
+#include <algorithm>
 #include <exception>
 #include <memory>
 #include <mutex>
@@ -101,14 +102,9 @@ void serial_manager_t::clean_ports() {
     }
     std::vector<std::string> to_remove;
     for (auto& [port, ser] : ports_) {
-        bool found = false;
-        for (const auto& info : available) {
-            if (info.port == port) {
-                found = true;
-                break;
-            }
+        if (!std::ranges::contains(available, port, &serial::PortInfo::port)) {
+            to_remove.emplace_back(port);
         }
-        if (!found) { to_remove.emplace_back(port); }
     }
     for (const auto& port : to_remove) { close_port(port); }
 }

--- a/src/esp32/serial.cpp
+++ b/src/esp32/serial.cpp
@@ -57,10 +57,15 @@ void serial_manager_t::start() {
     if (worker_.joinable()) { return; }
     keep_running_ = true;
     worker_       = std::jthread([this]() {
+        i32       scan_counter     = 0;
+        const i32 scan_counter_max = 200; // 200 * 5ms = 1 second
         while (keep_running_) {
-            this->clean_ports();
-            std::this_thread::sleep_for(1s);
+            if (scan_counter++ >= scan_counter_max) {
+                scan_counter = 0;
+                this->clean_ports();
+            }
             if (is_serial_write_) { this->receive_data(); }
+            std::this_thread::sleep_for(5ms);
         }
     });
 }
@@ -89,8 +94,8 @@ bool serial_manager_t::open_port(const std::string& port, const std::string& des
 
 // Close ports that have disappeared, open ports that have appeared
 void serial_manager_t::clean_ports() {
-    const std::scoped_lock              lock{mutex_};
     const std::vector<serial::PortInfo> available = serial::list_ports();
+    const std::scoped_lock              lock{mutex_};
     for (const auto& info : available) {
         if (!ports_.contains(info.port)) { open_port(info.port, info.description); }
     }

--- a/src/esp32/serial.cpp
+++ b/src/esp32/serial.cpp
@@ -55,12 +55,12 @@ serial_manager_t::~serial_manager_t() { stop(); }
 // Initializes and maintains Serial behavior
 void serial_manager_t::start() {
     if (worker_.joinable()) { return; }
-    keep_running = true;
+    keep_running_ = true;
     worker_      = std::jthread([this]() {
-        while (keep_running) {
+        while (keep_running_) {
             this->clean_ports();
             std::this_thread::sleep_for(1s);
-            if (is_serial_write) { this->receive_data(); }
+            if (is_serial_write_) { this->receive_data(); }
         }
     });
 }
@@ -207,7 +207,7 @@ bool serial_manager_t::is_running() const { return worker_.joinable(); }
 
 void serial_manager_t::stop() {
     if (!worker_.joinable()) { return; }
-    keep_running = false;
+    keep_running_ = false;
     worker_.join();
     close_all();
 }

--- a/tests/core/test_rw_latch.cpp
+++ b/tests/core/test_rw_latch.cpp
@@ -1,0 +1,54 @@
+#include <mutex>
+#include <shared_mutex>
+
+#include <catch_amalgamated.hpp>
+
+#include "core/rw_latch.hpp"
+
+namespace cairn::tests {
+
+TEST_CASE("rw_latch support manual lock cycles") {
+    mbr::rw_latch latch;
+
+    SECTION("Exclusive cycle") {
+        latch.lock();
+        latch.unlock();
+    }
+
+    SECTION("Shared cycle") {
+        latch.lock_shared();
+        latch.unlock_shared();
+    }
+
+    SECTION("Two concurrent shared holders on one thread") {
+        latch.lock_shared();
+        latch.lock_shared();
+        latch.unlock_shared();
+        latch.unlock_shared();
+    }
+}
+
+TEST_CASE("rw_latch honors try_lock semantics") {
+    mbr::rw_latch latch;
+
+    REQUIRE(latch.try_lock());
+    latch.unlock();
+
+    REQUIRE(latch.try_lock_shared());
+    latch.unlock_shared();
+}
+
+TEST_CASE("rw_latch supports use by std wrappers") {
+    mbr::rw_latch latch;
+
+    {
+        std::unique_lock exclusive{latch};
+        CHECK(exclusive.owns_lock());
+    }
+    {
+        std::shared_lock shared{latch};
+        CHECK(shared.owns_lock());
+    }
+}
+
+} // namespace cairn::tests

--- a/tests/core/test_time.cpp
+++ b/tests/core/test_time.cpp
@@ -1,4 +1,4 @@
-#include "catch_amalgamated.hpp"
+#include <catch_amalgamated.hpp>
 
 #include "core/time.hpp"
 


### PR DESCRIPTION
## Description

Addresses an issue where the backend's data lock was too strict and only allowed one reader or writer at a time. This is fixed by having a rw_latch that encapsulates a shared_mutex, providing instrumented data about the state of the lock during runtime.

Also makes changes to some of the monstrous classes, making public stateful members private to follow best practice and reordering some fields so that packing is nicer on object size.

Finally, resolved a bug where pressing stop on the serial page would halt the application. The thread now has a counter to check for port cleaning instead of always waiting a full second to poll.

There's likely some other things that should be fixed in this area of the application, but they are minor enough that moving to real UI improvements is likely the most logical next step.
